### PR TITLE
PSR-0

### DIFF
--- a/src/Ptlis/ContentNegotiation.php
+++ b/src/Ptlis/ContentNegotiation.php
@@ -1,5 +1,5 @@
 <?php
-
+namespace Ptlis;
 /****************************************************************************
 	*																		*
 	*	Version: content_negotiation.inc.php v2.0.2 2012-01-01				*
@@ -19,7 +19,7 @@
 	***************************************************************************/
 
 
-	class conNeg {
+	class ContentNegotiation {
 
 /**	@name	Specificness of quality factor match.
  *


### PR DESCRIPTION
Renamed class to ContentNegotiation.php and put it in the Ptlis vendor
namespace.

This is a very simple patch to make the conNeg class loadable by PSR-0 compatible autoloaders. I am not sure what to do about the compat folder, I'd suggest to branch it off and give it a version tag.

The patch introduces a vendor namespace, but no package namespace. A package namespace hierarchy is optional. See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
